### PR TITLE
Fix type exports in package.json.

### DIFF
--- a/.changeset/wet-snakes-fix.md
+++ b/.changeset/wet-snakes-fix.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fix type exports in package.json.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
     }
   },
   "license": "MIT",


### PR DESCRIPTION
I'm not an expert on node packages but this fixed my issue (output below) locally.

src/App.tsx:5:34 - error TS7016: Could not find a declaration file for module 'solid-codemirror'. '/repodir/node_modules/solid-codemirror/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/repodir/node_modules/solid-codemirror/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-codemirror' library may need to update its package.json or typings.

5 import { createCodeMirror } from "solid-codemirror";
                                   ~~~~~~~~~~~~~~~~~~

src/App.tsx:14:11 - error TS6133: 'editorView' is declared but its value is never read.

14   const { editorView, editorRef } = createCodeMirror();
             ~~~~~~~~~~


Found 2 errors in the same file, starting at: src/App.tsx:5